### PR TITLE
Add a thumbnailer file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -15,6 +15,14 @@ pbl_webp = shared_library('pixbufloader-webp', 'io-webp.c',
                           install: true,
                           install_dir: gdk_pb_moddir)
 
+cdata = configuration_data()
+cdata.set('bindir', get_option('prefix') / get_option('bindir'))
+configure_file(input: 'webp-pixbuf.thumbnailer.in',
+               output: 'webp-pixbuf.thumbnailer',
+               configuration: cdata,
+               install: true,
+               install_dir: get_option('datadir') / 'thumbnailer')
+
 meson.add_install_script(gdk_pb_query_loaders.path(), '--update-cache')
 
 subdir('tests')

--- a/webp-pixbuf.thumbnailer.in
+++ b/webp-pixbuf.thumbnailer.in
@@ -1,0 +1,4 @@
+[Thumbnailer Entry]
+TryExec=@bindir@/gdk-pixbuf-thumbnailer
+Exec=@bindir@/gdk-pixbuf-thumbnailer -s %s %u %o
+MimeType=image/webp;


### PR DESCRIPTION
If we want gdk-pixbuf-thumbnailer to generate thumbnails for WebP files,
we need to ship our own thumbnailer file.

Fixes: #16