### PR TITLE
Document Debian/Ubuntu meson build option

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,13 @@ Building from source
   meson builddir
   ninja -C builddir
   ```
-  
+
+  Build on Debian/Ubuntu:
+  ```
+  meson builddir -Dgdk_pixbuf_query_loaders_path=/usr/lib/x86_64-linux-gnu/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders
+  ninja -C builddir
+  ```
+
   Install:
   ```
   sudo ninja -C builddir install


### PR DESCRIPTION
@aruiz as #22 was the fourth question (#11, #9, #3) concerning the `gdk-pixbuf-query-loader` location I thought to document it more prominently.

After reading through the bug trackers, what is really responsible for the confusion and which is the best place to fix it? gdk-pixbuf upstream [added](https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/commit/039b7b788c0ba4711d50dd4430e3118ab267677b) a path that points to the usual PATH, but Debian/Ubuntu isn't symlinking the `gdk-pixbuf-query-loader`. Should upstream offer a better variable for meson to use?