### PR TITLE
Add option to set modules installation destination

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,9 @@
 project('webp-pixbuf-loader', 'c')
 gdkpb = dependency('gdk-pixbuf-2.0', version: '>2.22.0', method: 'pkg-config')
-gdk_pb_moddir = gdkpb.get_pkgconfig_variable('gdk_pixbuf_moduledir')
+gdk_pb_moddir = get_option('gdk_pixbuf_moduledir')
+if gdk_pb_moddir == ''
+  gdk_pb_moddir = gdkpb.get_pkgconfig_variable('gdk_pixbuf_moduledir')
+endif
 gdk_pb_query_loaders = gdkpb.get_pkgconfig_variable('gdk_pixbuf_query_loaders')
 webp = dependency('libwebp', version: '>0.4.3')
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('gdk_pixbuf_query_loaders_path', type: 'string', description: 'A non default path for the gdk-pixbuf-query-loaders binary')
+option('gdk_pixbuf_moduledir', type: 'string', description: 'The path to install gdk-pixbuf modules into')


### PR DESCRIPTION
Otherwise it's not possible to install it in non-system location, for
example in /app when the system gdk-pixbuf is using /usr.