### PR TITLE
Build with a .so library suffix on macOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,8 @@ gdk_pb_query_loaders = find_program(get_option('gdk_pixbuf_query_loaders_path'),
 pbl_webp = shared_library('pixbufloader-webp',
                           sources: ['io-webp.c', 'io-webp-anim.c'],
                           dependencies: [gdkpb, webp, webpdemux],
+                          # Workaround for https://gitlab.gnome.org/GNOME/glib/issues/1413
+                          name_suffix: host_machine.system() == 'darwin' ? 'so' : [],
                           install: true,
                           install_dir: gdk_pb_moddir)
 


### PR DESCRIPTION
The library suffix is expected to be `.so` rather than the default `.dylib`. Otherwise, tools like `gdk-pixbuf-query-loaders` won't pick up the plugin (https://gitlab.gnome.org/GNOME/glib/-/issues/1413)
This also matches how gdk-pixbuf is built on macOS (https://gitlab.gnome.org/GNOME/gdk-pixbuf/-/commit/2335d2191d599cb539a97a64bd76735cf0e9ec85)