### PR TITLE
added checking return value of 2 function calls.

### DIFF
--- a/io-webp-anim.c
+++ b/io-webp-anim.c
@@ -415,19 +415,21 @@ gdk_pixbuf_webp_anim_iter_advance (GdkPixbufAnimationIter *iter,
                 }
                 cur_frame += 1;
 
-                WebPAnimDecoderGetNext (decoder,
+                if (!WebPAnimDecoderGetNext (decoder,
                                         &webp_iter->webp_anim->curr_frame_ptr,
-                                        &timestamp);
-
+                                        &timestamp)) {
+                        return FALSE;
+                }
                 /*
                  * Frame duration can vary with each frame. WebPAnimDecoderGetNext does not
                  *   give access to the new duration. WebPDemuxGetFrame is used to update
                  *   the WebPIterator which contains duration.
                  */
-                WebPDemuxGetFrame (webp_iter->webp_anim->demuxer,
+                if (!WebPDemuxGetFrame (webp_iter->webp_anim->demuxer,
                                    cur_frame,
-                                   webp_iter->wpiter);
-
+                                   webp_iter->wpiter)) {
+                        return FALSE;
+                }
                 gboolean has_err = FALSE;
                 (void) data_to_pixbuf (webp_iter, &has_err);
                 if (has_err)


### PR DESCRIPTION
This fix should have no effect on normal usage.
The return value of 2 function calls were not checked. This fix puts the
checks in place.

WebPAnimDecoderGetNext(...) returns:
  False if any of the arguments are NULL, or if there is a parsing or
  decoding error, or if there are no more frames. Otherwise, returns true.

WebPDemuxGetFrame(...) returns:
	false if 'dmux' is NULL or frame 'frame_number' is not present.

Originally it was thought that these checks would interfere with automatic
replay of webp containers specified to continuously repeat. Testing shows
this is not the case. So the checks are put in. This aligns both occurences
of each of these function calls.

This will help if there are corrupted webp containers.
