### PR TITLE
Fix building on *BSD OS's and Solaris

### DIFF
--- a/io-webp.c
+++ b/io-webp.c
@@ -12,8 +12,13 @@
 
 #include "io-webp.h"
 
-#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#include <byteswap.h>
+#if defined(HAVE_ENDIAN_H)
+#include <endian.h>
+#elif defined(HAVE_SYS_ENDIAN_H)
+#include <sys/endian.h>
+#elif defined(HAVE_SYS_BYTEORDER_H)
+#include <sys/byteorder.h>
+#define le32toh(x) LE_32(x)
 #endif
 
 #define  IMAGE_READ_BUFFER_SIZE 65535
@@ -278,8 +283,8 @@ gdk_pixbuf__webp_anim_load_increment (gpointer      context,
                 /* The next 4 bytes give the size of the webp container less the 8 byte header. */
                 uint32_t anim_size = *(uint32_t *) (buf + 4); /* gives file size not counting the first 8 bytes. */
 
-                #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-		anim_size = bswap_32(anim_size);
+                #ifndef _WIN32
+                anim_size = le32toh(anim_size);
                 #endif
 
                 uint32_t file_size = anim_size + 8;

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,5 @@
 project('webp-pixbuf-loader', 'c', meson_version: '>=0.53')
+cc = meson.get_compiler('c')
 gdkpb = dependency('gdk-pixbuf-2.0', version: '>2.22.0', method: 'pkg-config')
 gdk_pb_moddir = get_option('gdk_pixbuf_moduledir')
 if gdk_pb_moddir == ''
@@ -18,6 +19,18 @@ endif
 
 # -34/-64 is to overcome a Fedora bug in the .pc file
 gdk_pb_query_loaders = find_program(get_option('gdk_pixbuf_query_loaders_path'), gdk_pb_query_loaders, gdk_pb_query_loaders+'-32', gdk_pb_query_loaders+'-64', dirs: dirs)
+
+headers = [
+  'endian.h',
+  'sys/endian.h',
+  'sys/byteorder.h',
+]
+
+foreach h : headers
+  if cc.has_header(h)
+    add_global_arguments('-DHAVE_' + h.underscorify().to_upper(), language : 'c')
+  endif
+endforeach
 
 pbl_webp = shared_module('pixbufloader-webp',
                          sources: ['io-webp.c', 'io-webp-anim.c'],


### PR DESCRIPTION
This fixes building on OpenBSD and other *BSD OS's as well as Solaris.

byteswap.h is a Linux header.

endian.h is part of POSIX and exists on Linux (glibc, musl, Bionic), OpenBSD, NetBSD and DragonFlyBSD. FreeBSD does not have said header (at the moment) so fallback to sys/endian.h; they're very close.

Solaris uses sys/byteorder.h and I have used the appropriate macro in the Solaris header.