### PR TITLE
Add Visual Studio build support

### DIFF
--- a/io-webp-anim.c
+++ b/io-webp-anim.c
@@ -495,7 +495,7 @@ get_data_from_file (FILE        *f,
         /* Check for RIFF and WEBP tags in WebP container header. */
         char tag[5];
         tag[4] = 0;
-        for (int i = 0; i < 4; i++) { tag[i] = *(gchar *) (data + i); }
+        for (int i = 0; i < 4; i++) { tag[i] = *((gchar *)data + i); }
         int rc2 = strcmp (tag, "RIFF");
         if (rc2 != 0) {
                 g_set_error (error,
@@ -504,7 +504,7 @@ get_data_from_file (FILE        *f,
                              "Cannot read WebP image header...");
                 return;
         }
-        for (int i = 0; i < 4; i++) { tag[i] = *(gchar *) (data + 8 + i); }
+        for (int i = 0; i < 4; i++) { tag[i] = *((gchar *)data + 8 + i); }
         rc2 = strcmp (tag, "WEBP");
         if (rc2 != 0) {
                 g_set_error (error,

--- a/io-webp.c
+++ b/io-webp.c
@@ -655,7 +655,7 @@ gdk_pixbuf__webp_image_save_to_callback (GdkPixbufSaveFunc   save_func,
                                TRUE, NULL, &context);
 }
 
-void
+G_MODULE_EXPORT void
 fill_vtable (GdkPixbufModule *module)
 {
         module->load = gdk_pixbuf__webp_image_load;
@@ -667,7 +667,7 @@ fill_vtable (GdkPixbufModule *module)
         module->load_animation = gdk_pixbuf__webp_image_load_animation;
 }
 
-void
+G_MODULE_EXPORT void
 fill_info (GdkPixbufFormat *info)
 {
         static GdkPixbufModulePattern signature[] = {

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -5,8 +5,16 @@ t2 = executable('t2', 't2.c', dependencies : [gdkpb, webp, webpdemux])
 t3 = executable('t3', 't3.c', dependencies : [gdkpb, webp, webpdemux])
 t4 = executable('t4', 't4.c', dependencies : [gdkpb, webp, webpdemux])
 
+if meson.version().version_compare('>=0.54.0')
+  # The Meson fs.as_posix() feature was introduced in 0.54.0
+  fs = import('fs')
+  module_path = fs.as_posix(pbl_webp.full_path())
+else
+  module_path = pbl_webp.full_path().replace('\\', '/')
+endif
+
 loaders_data = configuration_data()
-loaders_data.set('MODULE_PATH', pbl_webp.full_path())
+loaders_data.set('MODULE_PATH', module_path)
 loaders = configure_file(input: 'loaders.cache.in',
                          output : 'loaders.cache',
                          configuration : loaders_data)

--- a/tests/t3.c
+++ b/tests/t3.c
@@ -2,11 +2,11 @@
 
 gint
 main(gint argc, gchar **argv) {
-        g_autoptr(GdkPixbufAnimation) anim = gdk_pixbuf_animation_new_from_file(g_getenv("TEST_FILE"), NULL);
+        GdkPixbufAnimation *anim = gdk_pixbuf_animation_new_from_file(g_getenv("TEST_FILE"), NULL);
         g_assert(anim != NULL);
         g_assert(!gdk_pixbuf_animation_is_static_image(anim)); // Make sure it is an animation
 
-        g_autoptr(GdkPixbufAnimationIter) anim_iter = gdk_pixbuf_animation_get_iter(anim, NULL);
+        GdkPixbufAnimationIter *anim_iter = gdk_pixbuf_animation_get_iter(anim, NULL);
         g_assert(anim_iter != NULL);
 
         int nframes;
@@ -31,5 +31,7 @@ main(gint argc, gchar **argv) {
                         g_assert_cmpint(delay, ==, 300);
         }
         g_assert(nframes == 15);
+        g_object_unref (anim_iter);
+        g_object_unref (anim);
         return 0;
 }


### PR DESCRIPTION
Hi,

This attempts to enable the sources to be built with Visual Studio on Windows, by:

*  Dropping GCCisms on pointer arithmetic and (sadly) `g_autoptr` in the sources and tests, so that the sources will build.
*  Ensure that needed symbols are exported during the build, so that GdkPixbuf can load the loader module.
*  Ensure that the test `loaders.cache` is correctly generated for Visual Studio (`cmd.exe` console, Windows-style paths) builds, so that the tests will run properly.  I did things a bit conservatively to keep Meson 0.53.0 compatibility, but let me know if it's OK to just bump the Meson version.

The tests build and run successfully on Visual Studio 2015 and Visual Studio 2022 for both x86 and x64 build targets, and building for ARM64 Windows on Visual Studio 2017 15.9.x succeeded.

With blessings, thank you!