### PR TITLE
io-webp.c: update_func() shall be called for proper signal delivery.

### DIFF
--- a/io-webp.c
+++ b/io-webp.c
@@ -176,6 +176,9 @@ stop_load (gpointer data, GError **error)
           return FALSE;
         }
 
+      if (context->prepare_func)
+        context->prepare_func (pb, NULL, context->user_data);
+
       if (icc_data)
         {
           gdk_pixbuf_set_option (pb, "icc-profile", icc_data);
@@ -189,12 +192,8 @@ stop_load (gpointer data, GError **error)
                                          context->buffer->len, &config);
       if (status == VP8_STATUS_OK)
         {
-          if (context->prepare_func)
-            context->prepare_func (pb, NULL, context->user_data);
           if (context->update_func)
             context->update_func (pb, 0, 0, context->width, context->height, context->user_data);
-
-          g_clear_object (&pb);
 
           ret = TRUE;
         }
@@ -202,6 +201,8 @@ stop_load (gpointer data, GError **error)
         g_set_error (error, GDK_PIXBUF_ERROR, GDK_PIXBUF_ERROR_FAILED,
                           "WebP decoder failed with VP8 status code: %d", status);
       }
+
+      g_clear_object (&pb);
     }
 
   if (context->buffer)

--- a/io-webp.c
+++ b/io-webp.c
@@ -189,6 +189,8 @@ stop_load (gpointer data, GError **error)
         {
           if (context->prepare_func)
             context->prepare_func (pb, NULL, context->user_data);
+          if (context->update_func)
+            context->update_func (pb, 0, 0, context->width, context->height, context->user_data);
 
           g_clear_object (&pb);
 

--- a/io-webp.c
+++ b/io-webp.c
@@ -143,6 +143,8 @@ stop_load (gpointer data, GError **error)
         {
           if (context->prepare_func)
             context->prepare_func (pb, GDK_PIXBUF_ANIMATION (anim), context->user_data);
+          if (context->update_func)
+            context->update_func (pb, 0, 0, context->width, context->height, context->user_data);
           ret = TRUE;
         }
 


### PR DESCRIPTION
After this commit https://github.com/aruiz/webp-pixbuf-loader/commit/36b3df08 (after 0.2.1), GdkPixBuf `PixbufModuleUpdatedFunc` (i.e. `context->update_func()`) is no longer called in either `load_increment()` or `stop_load()`.

As GdkPixBuf manual pages say, GdkPixbufLoader uses `PixbufModulePreparedFunc` to emit the “area_prepared” signal and also uses `PixbufModuleUpdatedFunc` to emit the “area_updated” signal:
 https://docs.gtk.org/gdk-pixbuf/callback.PixbufModulePreparedFunc.html
 https://docs.gtk.org/gdk-pixbuf/callback.PixbufModuleUpdatedFunc.html

So if a rendering window is in the main thread and loading and decoding ops are in the background process, the main thread will never be notified completion of decoding in the background process and none will be rendered, unless “area_updated” signal is delivered.