### PR TITLE
workflows: bump checkout action to v4

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -12,7 +12,7 @@ jobs:
   Build:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: brew update
       - run: brew install webp gdk-pixbuf meson ninja pkg-config
       - run: meson setup build

--- a/.github/workflows/msys2.yml
+++ b/.github/workflows/msys2.yml
@@ -1,11 +1,13 @@
 name: WebP Pixbuf CI [MSYS2]
-'on':
+
+on:
   push:
     branches:
       - mainline
   pull_request:
     branches:
       - mainline
+
 jobs:
   build:
     runs-on: windows-latest
@@ -18,7 +20,7 @@ jobs:
       run:
         shell: msys2 {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: msys2/setup-msys2@v2
         with:
           msystem: ${{matrix.sys}}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -1,16 +1,18 @@
 name: WebP Pixbuf CI [Ubuntu]
-'on':
+
+on:
   push:
     branches:
       - mainline
   pull_request:
     branches:
       - mainline
+
 jobs:
   Build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: sudo apt update
       - run: sudo apt install ninja-build meson libwebp-dev libgdk-pixbuf2.0-dev valgrind
       - run: mkdir build


### PR DESCRIPTION
bump checkout action to v4 (which runs on nodejs 20)