### PR TITLE
Update meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('webp-pixbuf-loader', 'c', meson_version: '>=0.54')
+project('webp-pixbuf-loader', 'c', version: '0.2.6', meson_version: '>=0.54')
 cc = meson.get_compiler('c')
 gio = dependency('gio-2.0', method: 'pkg-config')
 gdkpb = dependency('gdk-pixbuf-2.0', version: '>2.22.0', method: 'pkg-config')


### PR DESCRIPTION
This updates the meson.build file to include the version number of the release instead of it saying undefined it now states the version number.
![image](https://github.com/aruiz/webp-pixbuf-loader/assets/46272571/2a7b6b81-c2e1-40b8-b023-19c42ccf871a)
