### PR TITLE
workflow(macos): remove py3.11 links and add upstream discussion note

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -19,6 +19,7 @@ jobs:
           brew update
 
           # fix `brew link python@3.12` issue
+          # see upstream discussion in https://github.com/actions/setup-python/issues/577
 
           rm -f /usr/local/bin/2to3
           rm -f /usr/local/bin/idle3

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,6 +26,11 @@ jobs:
           rm -f /usr/local/bin/pydoc3
           rm -f /usr/local/bin/python3
           rm -f /usr/local/bin/python3-config
+          rm -f /usr/local/bin/2to3-3.11
+          rm -f /usr/local/bin/idle3.11
+          rm -f /usr/local/bin/pydoc3.11
+          rm -f /usr/local/bin/python3.11
+          rm -f /usr/local/bin/python3.11-config
           rm -f /usr/local/bin/2to3-3.12
           rm -f /usr/local/bin/idle3.12
           rm -f /usr/local/bin/pydoc3.12


### PR DESCRIPTION
relates to #84 